### PR TITLE
🐛 Fix deploy error when page access restricted

### DIFF
--- a/lib/notion.js
+++ b/lib/notion.js
@@ -8,7 +8,7 @@ export async function getAllPosts () {
   const collectionId = Object.keys(page.collection)[0]
   const collectionViewId = Object.keys(page.collection_view)[0]
   const root = await api.getCollectionData(collectionId, collectionViewId)
-  const articles = root.result.blockIds.map(id => root.recordMap.block[id])
+  const articles = root.result.blockIds.map(id => root.recordMap.block[id]).filter(article => article.role != "none")
   const properties = Object.values(root.recordMap.collection)[0].value.schema
   const metaData = articles.map(art => {
     const propertiesInArticle = Object.entries(properties).reduce(


### PR DESCRIPTION
Every page in a shared database will be shared to web by default based on the share settings of the parent. If some pages switch off the Share to web option (meaning restrict access), the deploy will fail. This commit adds a filter for articles, to remove those have no access to the public. So now you can restrict some pages access, and they will not show on the site or in the database to the public.