### PR TITLE
🐛 Fix only show "Copy of " for a duplicated page

### DIFF
--- a/lib/notion.js
+++ b/lib/notion.js
@@ -28,7 +28,7 @@ export async function getAllPosts () {
 
     const artMeta = {
       id: art.value.id,
-      title: art.value.properties.title[0][0],
+      title: art.value.properties.title.join(''),
       ...propertiesInArticle
     }
     if (artMeta.tags) {


### PR DESCRIPTION
The page title is like this: `[["Copy of "], ["Page Title"]]`. So if use `tittle[0][0]`, it will only get `Copy of `. I changed to `title.join('')` to fix this bug.