### PR TITLE
🐛 Fix summary incomplete and deploy error when summary empty

### DIFF
--- a/lib/notion.js
+++ b/lib/notion.js
@@ -13,13 +13,18 @@ export async function getAllPosts () {
   const metaData = articles.map(art => {
     const propertiesInArticle = Object.entries(properties).reduce(
       (properties, [id, { name }]) => {
-        if (id !== 'title' && name !== 'date') {
+        if (id !== 'title' && name !== 'date' && name !== 'summary') {
           Array.isArray(art.value.properties[id])
             ? (properties[name] = art.value.properties[id][0][0])
             : (properties[name] = art.value.properties[id])
         }
         if (name === 'date') {
           properties[name] = art.value.properties[id][0][1][0][1].start_date
+        }
+        if (name === 'summary') {
+          Array.isArray(art.value.properties[id])
+            ? (properties[name] = art.value.properties[id].reduce((acc, val) => acc.concat(val[0] != '⁍' ? val[0] : '')).join(''))
+            : (properties[name] = null)
         }
         return properties
       },


### PR DESCRIPTION
The summary only shows the content before a styled text previously, so I extract all the texts to get a plain summary. Also, an inline equation will be shown as `⁍`, so I just delete it. And I set the value to null when summary empty to prevent deploy error.