### PR TITLE
[Language] Fix: '返回'  → 'Back' in English

### DIFF
--- a/lib/lang.js
+++ b/lib/lang.js
@@ -11,7 +11,7 @@ const lang = {
       NEXT: 'Next'
     },
     POST: {
-      BACK: '返回',
+      BACK: 'Back',
       TOP: 'Top'
     }
   },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11225092/111861000-ee80b480-8985-11eb-8f60-4eef09e7cf6b.png)

The bug mentioned by Mar.