### PR TITLE
🐛 Format title & summary & slug to plain text. Fix deploy error when date empty

### DIFF
--- a/lib/notion.js
+++ b/lib/notion.js
@@ -15,20 +15,22 @@ export async function getAllPosts () {
   const metaData = articles.map(art => {
     const propertiesInArticle = Object.entries(properties).reduce(
       (properties, [id, { name }]) => {
-        if (id !== 'title' && name !== 'date' && name !== 'summary') {
+        if (id !== 'title' && name !== 'date' && name !== 'summary' && name !== 'slug') {
           Array.isArray(art.value.properties[id])
             ? (properties[name] = art.value.properties[id][0][0])
             : (properties[name] = art.value.properties[id])
         }
         if (name === 'date') {
-          properties[name] = art.value.properties[id][0][1][0][1].start_date
+          Array.isArray(art.value.properties[id])
+            ? (properties[name] = art.value.properties[id][0][1][0][1].start_date)
+            : (properties[name] = art.value.properties[id] || null)
         }
-        if (name === 'summary') {
+        if (name === 'summary' || name === 'slug') {
           Array.isArray(art.value.properties[id])
             ? (properties[name] = art.value.properties[id]
-                .reduce((acc, val) => acc.concat(val[0] !== '⁍' ? val[0] : ''))
+                .reduce((acc, val) => acc.concat((val[0] !== '⁍' && val[0] != '‣') ? val[0] : ''))
                 .join(''))
-            : (properties[name] = null)
+            : (properties[name] = art.value.properties[id] || null)
         }
         return properties
       },
@@ -37,7 +39,9 @@ export async function getAllPosts () {
 
     const artMeta = {
       id: art.value.id,
-      title: art.value.properties.title.join(''),
+      title: art.value.properties.title
+        .reduce((acc, val) => acc.concat((val[0] !== '⁍' && val[0] != '‣') ? val[0] : ''))
+        .join(''),
       ...propertiesInArticle
     }
     if (artMeta.tags) {


### PR DESCRIPTION
Previously, I formatted summary to plain text, but forgot the @ (date, person, page) will show as '‣'. Now I fixed it, and also formatted title and slug to plain text. Another thing is fix deploy error when date empty. I think an empty date should be allowed, if status is not published. And now, if a published page don't have a date, January 1, 1970 will be shown in nobelium.