### PR TITLE
🐛 fix check type use collection_view

### DIFF
--- a/lib/notion/getAllPosts.js
+++ b/lib/notion/getAllPosts.js
@@ -19,7 +19,7 @@ export async function getAllPosts() {
   const rawMetadata = block[id].value
 
   // Check Type
-  if (rawMetadata?.type !== 'collection_view_page') {
+  if (rawMetadata?.type !== 'collection_view_page' && rawMetadata?.type !== 'collection_view') {
     console.log(`pageId "${id}" is not a database`)
     return null
   } else {


### PR DESCRIPTION
Seems Notion has changed block[DBid].value.type from 'collection_view_page' to 'collection_view'. Some old public databases have not changed, and they may change when an admin view or edit. So I changed the code to make the two type both work.