### PR TITLE
feat(rss): Add support for RSS content

### DIFF
--- a/lib/rss.js
+++ b/lib/rss.js
@@ -1,7 +1,28 @@
 import { Feed } from 'feed'
 import BLOG from '@/blog.config'
+import ReactDOMServer from 'react-dom/server'
+import { getPostBlocks } from '@/lib/notion'
+import { NotionRenderer, Equation, Code, Collection, CollectionRow } from 'react-notion-x'
 
-export function generateRss (posts) {
+const mapPageUrl = id => 'https://www.notion.so/' + id.replace(/-/g, '')
+
+const createFeedContent = async post => {
+  let content = ReactDOMServer.renderToString(<NotionRenderer
+    recordMap={await getPostBlocks(post.id)}
+    components={{
+      equation: Equation,
+      code: Code,
+      collection: Collection,
+      collectionRow: CollectionRow
+    }}
+    mapPageUrl={mapPageUrl}
+  />)
+  const regexExp = /<div class="notion-collection-row"><div class="notion-collection-row-body"><div class="notion-collection-row-property"><div class="notion-collection-column-title"><svg.*?class="notion-collection-column-title-icon">.*?<\/svg><div class="notion-collection-column-title-body">.*?<\/div><\/div><div class="notion-collection-row-value">.*?<\/div><\/div><\/div><\/div>/g
+  content = content.replace(regexExp, '')
+  return content
+}
+
+export async function generateRss (posts) {
   const year = new Date().getFullYear()
   const feed = new Feed({
     title: BLOG.title,
@@ -9,7 +30,7 @@ export function generateRss (posts) {
     id: `${BLOG.link}/${BLOG.path}`,
     link: `${BLOG.link}/${BLOG.path}`,
     language: BLOG.lang,
-    favicon: `${BLOG.link}/favicon.png`,
+    favicon: `${BLOG.link}/favicon.svg`,
     copyright: `All rights reserved ${year}, ${BLOG.author}`,
     author: {
       name: BLOG.author,
@@ -17,14 +38,15 @@ export function generateRss (posts) {
       link: BLOG.link
     }
   })
-  posts.forEach(post => {
+  for (const post of posts) {
     feed.addItem({
       title: post.title,
       id: `${BLOG.link}/${post.slug}`,
       link: `${BLOG.link}/${post.slug}`,
       description: post.summary,
+      content: await createFeedContent(post),
       date: new Date(post?.date?.start_date || post.createdTime)
     })
-  })
-  return feed.rss2()
+  }
+  return feed.atom1()
 }

--- a/pages/feed.js
+++ b/pages/feed.js
@@ -4,7 +4,7 @@ export async function getServerSideProps ({ res }) {
   res.setHeader('Content-Type', 'text/xml')
   const posts = await getAllPosts({ includePages: false })
   const latestPosts = posts.slice(0, 10)
-  const xmlFeed = generateRss(latestPosts)
+  const xmlFeed = await generateRss(latestPosts)
   res.write(xmlFeed)
   res.end()
   return {


### PR DESCRIPTION
Add support for `RSS content` , which allows RSS readers to preview web page content directly through .

BTW, I changed the generator function from `rss2` to `atom1` because I found that some attributes (e.g. author, favicon) were not generated correctly with `rss2` , while it worked fine with `atom1` .

Before
<img width="100%" alt="image" src="https://user-images.githubusercontent.com/13177224/143670008-aa8089f3-a820-4d56-a3ea-368d4e7aa561.png">

After
<img width="100%" alt="image" src="https://user-images.githubusercontent.com/13177224/143669968-b4687d58-9e5d-4713-b225-047b6866e29f.png">

Preview in RSS readers
<img width="100%" alt="image" src="https://user-images.githubusercontent.com/13177224/143670138-9c774048-05cb-4d0e-8555-d4a6403ddb62.png">

