### PR TITLE
chore: upgrade react-notion-x to prevent code block render error

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react": "^17.0.2",
     "react-cusdis": "^2.0.1",
     "react-dom": "^17.0.2",
-    "react-notion-x": "^4.11.0",
+    "react-notion-x": "^4.15.0",
     "use-ackee": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
当前版本的 react-notion-x 在使用 typescript 代码时会出 bug，包括不渲染代码样式或者整个代码块不显示，这个问题在 react-notion-x 侧已经解决，需要更新依赖。
参考资料：
https://github.com/NotionX/react-notion-x/issues/62
https://github.com/NotionX/react-notion-x/pull/194