### PR TITLE
fix: Remove extra spaces in Dockerfile to avoid build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NOTION_PAGE_ID = 
+ARG NOTION_PAGE_ID= 
 # Install dependencies only when needed
 FROM node:14-alpine AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.


### PR DESCRIPTION
After the ARG parameter in the first line of the Dockerfile, there is an extra space between the parameter name and the space, which causes the docker build command to report an error.
![image](https://user-images.githubusercontent.com/39008983/158849799-d3409064-cbf6-48be-9b20-d11eeea339ae.png)
