### PR TITLE
support get page content from relation property

### DIFF
--- a/lib/notion/getPageProperties.js
+++ b/lib/notion/getPageProperties.js
@@ -4,11 +4,10 @@ import { NotionAPI } from 'notion-client'
 async function getPageProperties (id, block, schema, authToken) {
   const api = new NotionAPI({ authToken })
   const rawProperties = Object.entries(block?.[id]?.value?.properties || [])
-  const excludeProperties = ['date', 'select', 'multi_select', 'person']
+  const excludeProperties = ['date', 'select', 'multi_select', 'person', 'relation']
   const properties = {}
   for (let i = 0; i < rawProperties.length; i++) {
     const [key, val] = rawProperties[i]
-    properties.id = id
     if (schema[key]?.type && !excludeProperties.includes(schema[key].type)) {
       properties[schema[key].name] = getTextContent(val)
     } else {
@@ -48,11 +47,19 @@ async function getPageProperties (id, block, schema, authToken) {
           properties[schema[key].name] = users
           break
         }
+        case 'relation': {
+          const selects = val?.[0][1][0][1]
+          if (selects?.length) {
+            properties.id = selects
+          }
+          break
+        }
         default:
           break
       }
     }
   }
+  properties.id = properties.id || id
   return properties
 }
 


### PR DESCRIPTION
## Aim
I have many different database to save different category blogs. Like life and learn. If I want to post them, I must move them to blog database, It is hard to manage my notes.

## Solution
The pr now support  add any relation properties to origin blog database. It will select first not empty relation as blog content.

If no relation, it still select origin blog content. 