### PR TITLE
fix: Google search unrecognized sitemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.1",
     "eslint-plugin-react": "^7.26.1",
-    "next-sitemap": "^1.6.203",
+    "next-sitemap": "^3.1.47",
     "postcss": "^8.3.11",
     "tailwindcss": "^2.2.19"
   },


### PR DESCRIPTION
## Bug

Google search console  Cannot recognize sitemap.

## Fix

Sitemap cannot work because it's version is too low.
When I try to update this package, it works normally.

![image](https://i.niupic.com/images/2023/01/25/agz3.png)
