### PR TITLE
🐛 Bookmark nested in a Callout may overflow on small screens (closes #240)

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -24,6 +24,10 @@ svg + .notion-page-title-text {
   @apply border-b-0;
 }
 
+.notion-callout-text {
+  @apply min-w-0;
+}
+
 .notion-bookmark {
   @apply border;
   @apply border-gray-100;


### PR DESCRIPTION
## Description

When a Bookmark block is nested within a Callout block and the viewport width is small enough, the Bookmark block may exceed the right border of the Callout block. This PR fixes the issue.

## Related Issues

Issue #240 