### PR TITLE
Set the width of List block (closes #238)

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -71,6 +71,9 @@ pre[class*='language-'] {
 .notion-quote {
   padding: 0.2em 0.9em;
 }
+.notion-list {
+  width: 100%;
+}
 .notion-collection {
   @apply max-w-full;
 }


### PR DESCRIPTION
## Description

The list block has no width set, which causes some blocks (like the Code block) inside of it to consume too much horizontal space. Therefore, a horizontal scrollbar may appear on the viewport. This PR fixes the issue.

## Related Issues

#238, #137