### PR TITLE
🐛 Slug is not included in og:url

### DIFF
--- a/layouts/layout.js
+++ b/layouts/layout.js
@@ -85,6 +85,7 @@ const Layout = ({
       layout="blog"
       title={frontMatter.title}
       description={frontMatter.summary}
+      slug={frontMatter.slug}
       // date={new Date(frontMatter.publishedAt).toISOString()}
       type="article"
       fullWidth={fullWidth}


### PR DESCRIPTION
## Description

The page slug was not included in `og:url` because the necessary prop was not provided to `<Container>`. This PR fixes the issue.

## Related Issues

#252 