### PR TITLE
Fix code block style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # misc
 .DS_Store
 .idea
+.vscode
 *.pem
 
 # debug

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -43,10 +43,6 @@ svg + .notion-page-title-text {
   @apply text-gray-600 dark:text-gray-300;
 }
 
-.notion-code > code {
-  @apply text-gray-900;
-}
-
 pre[class*='language-'] {
   line-height: inherit;
 }


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/8568876/225797937-b9f09f8f-7a39-4c0d-a405-c083787878d3.png)

after:

![image](https://user-images.githubusercontent.com/8568876/225798017-ca60892a-477d-4a6d-af28-7606811fe51d.png)

Both dark mode and light mode works appropriately.