### PR TITLE
fix: import the correct nested server config

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,4 +1,4 @@
-const config = require('./lib/server/config')
+const { config }  = require('./lib/server/config')
 
 module.exports = {
   siteUrl: config.link,


### PR DESCRIPTION

<img width="519" alt="image" src="https://user-images.githubusercontent.com/16360498/229411466-5cf73400-07ac-4918-8a1d-0b18b86bb16c.png">



Seems like the export config is different from the import config of sitemap. Due to which it is throwing undefined for the link.