### PR TITLE
Add support for Vercel Analytics 

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -26,7 +26,7 @@ const BLOG = {
   notionPageId: process.env.NOTION_PAGE_ID, // DO NOT CHANGE THIS！！！
   notionAccessToken: process.env.NOTION_ACCESS_TOKEN, // Useful if you prefer not to make your database public
   analytics: {
-    provider: '', // Currently we support Google Analytics and Ackee, please fill with 'ga' or 'ackee', leave it empty to disable it.
+    provider: '', // Currently we support Google Analytics, Ackee and Vercel Analytics, please fill with 'ga' or 'ackee' or 'vercel', leave it empty to disable it.
     ackeeConfig: {
       tracker: '', // e.g 'https://ackee.craigary.net/tracker.js'
       dataAckeeServer: '', // e.g https://ackee.craigary.net , don't end with a slash
@@ -34,7 +34,8 @@ const BLOG = {
     },
     gaConfig: {
       measurementId: '' // e.g: G-XXXXXXXXXX
-    }
+    },
+    vercelConfig: {}
   },
   comment: {
     // support provider: gitalk, utterances, cusdis

--- a/components/Scripts.js
+++ b/components/Scripts.js
@@ -28,6 +28,9 @@ const Scripts = () => {
           </Script>
         </>
       )}
+      {BLOG.analytics && BLOG.analytics.provider === 'vercel' && (
+        <script defer src="/_vercel/insights/script.js"></script>
+      )}
     </>
   )
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "postbuild": "next-sitemap --config next-sitemap.config.js"
   },
   "dependencies": {
+    "@vercel/analytics": "^1.0.2",
     "axios": "^1.3.4",
     "classnames": "^2.3.2",
     "dayjs": "^1.11.7",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -14,6 +14,7 @@ import Scripts from '@/components/Scripts'
 
 const Ackee = dynamic(() => import('@/components/Ackee'), { ssr: false })
 const Gtag = dynamic(() => import('@/components/Gtag'), { ssr: false })
+const Analytics = dynamic(() => import('@vercel/analytics/react'), { ssr: false })
 
 export default function MyApp ({ Component, pageProps, config, locale }) {
   return (
@@ -29,6 +30,7 @@ export default function MyApp ({ Component, pageProps, config, locale }) {
               />
             )}
             {process.env.VERCEL_ENV === 'production' && config?.analytics?.provider === 'ga' && <Gtag />}
+            {process.env.VERCEL_ENV === 'production' && config?.analytics?.provider === 'vercel' && <Analytics />}
             <Component {...pageProps} />
           </>
         </ThemeProvider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ patchedDependencies:
     path: patches/react-notion-x@6.16.0.patch
 
 dependencies:
+  '@vercel/analytics':
+    specifier: ^1.0.2
+    version: 1.0.2
   axios:
     specifier: ^1.3.4
     version: 1.3.4
@@ -512,6 +515,10 @@ packages:
       '@typescript-eslint/types': 5.55.0
       eslint-visitor-keys: 3.3.0
     dev: true
+
+  /@vercel/analytics@1.0.2:
+    resolution: {integrity: sha512-BZFxVrv24VbNNl5xMxqUojQIegEeXMI6rX3rg1uVLYUEXsuKNBSAEQf4BWEcjQDp/8aYJOj6m8V4PUA3x/cxgg==}
+    dev: false
 
   /@webassemblyjs/ast@1.11.1:
     resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}


### PR DESCRIPTION
Hi,

This adds support for the Vercel’s analytics service, see https://vercel.com/docs/concepts/analytics/quickstart .

I have toggled Allow edits by maintainers so if this is not exactly what you want, you can modify it anyways.

Best.