### PR TITLE
fix: removed tag not show in search

### DIFF
--- a/lib/notion/getPageProperties.js
+++ b/lib/notion/getPageProperties.js
@@ -1,7 +1,7 @@
 import { getTextContent, getDateValue } from 'notion-utils'
 import api from '@/lib/server/notion-api'
 
-async function getPageProperties (id, block, schema) {
+async function getPageProperties(id, block, schema) {
   const rawProperties = Object.entries(block?.[id]?.value?.properties || [])
   const excludeProperties = ['date', 'select', 'multi_select', 'person']
   const properties = {}
@@ -22,7 +22,12 @@ async function getPageProperties (id, block, schema) {
         case 'multi_select': {
           const selects = getTextContent(val)
           if (selects[0]?.length) {
-            properties[schema[key].name] = selects.split(',')
+            let selectedValues = selects.split(',').map(v => v.trim())
+            if (schema[key].options) {
+              const validOptionsSet = new Set(schema[key].options.map(o => o.value))
+              selectedValues = selectedValues.filter(v => validOptionsSet.has(v))
+            }
+            properties[schema[key].name] = selectedValues
           }
           break
         }


### PR DESCRIPTION
Fix Ghost Tags in Nobelium Search
The reason deleted Notion tags like #temp and Jekyll are still showing up in the search results is due to how Nobelium parses Notion data.

When you delete a tag from the Multi-select options in Notion, Notion removes it from the "valid schema options", but the raw internal data for specific pages might still contain the string of the deleted tag. Because Nobelium simply extracts the raw text from each page's properties without cross-referencing the "valid options" available in your Notion database, the ghost tags are still surfaced.

Nobelium > Search: still show the removed tag
<img width="640" height="140" alt="image (1)" src="https://github.com/user-attachments/assets/a51a387c-3fd5-4520-a822-8d679dcf8d04" />

Reference: Notion tag properties after modified
<img width="300" height="250" alt="image" src="https://github.com/user-attachments/assets/1f26b909-a320-400a-ab6c-f21c92c2c18c" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multi-select field validation to restrict selections to schema-defined options, improving data integrity and preventing invalid entries.
  * Trimmed whitespace from multi-select values to avoid accidental mismatches and ensure consistent stored selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->